### PR TITLE
fix: update docs to indicate current library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The package can be installed by adding `logger_loki_backend` to your list of dep
 ```elixir
 def deps do
   [
-    {:logger_loki_backend, "~> 0.3.0"}
+    {:logger_loki_backend, "~> 0.0.1"}
   ]
 end
 ```


### PR DESCRIPTION
The README does not retained the version number from the `loki_logger`. this PR updates the doc to use the actual version number here.